### PR TITLE
Use multiple lines for partial-permutation equation.

### DIFF
--- a/counting.tex
+++ b/counting.tex
@@ -499,8 +499,9 @@ only wanted to carry out the multiplication to 36 (not 35), and 36 is
 This can be expressed more compactly in a few different ways. First,
 we can use factorials to represent it:
 \begin{align*}
-n \times (n-1) \times (n-2) \times \cdots \times (n-k+1) &= \\
-\dfrac{n \times (n-1) \times (n-2) \times \cdots \times 1}{(n-k) \times (n-k-1) \times (n-k-2) \times \cdots \times 1} &= \dfrac{n!}{(n-k)!}.
+& n \times (n-1) \times (n-2) \times \cdots \times (n-k+1) \\
+&= \dfrac{n \times (n-1) \times (n-2) \times \cdots \times 1}{(n-k) \times (n-k-1) \times (n-k-2) \times \cdots \times 1} \\
+&= \dfrac{n!}{(n-k)!}
 \end{align*}
 \index{product operator ($\Pi$)}
 Also, we could use our compact product notation:


### PR DESCRIPTION
Found myself staring at 
![confusion](https://user-images.githubusercontent.com/26764547/203027531-4caf96ac-540c-460a-813e-044e0ac16021.png)
for a while this morning.  Almost thought it was a system of linear equations (but with the first equation missing some info) or something.

The change makes it look like:
![better-ish](https://user-images.githubusercontent.com/26764547/203028042-27923a68-06be-41d9-918b-5de79f63fcff.png)
which, I think, is more readable.
