### PR TITLE
Use consistent terminology.

### DIFF
--- a/counting.tex
+++ b/counting.tex
@@ -636,14 +636,14 @@ This makes a total of six times that we (redundantly) counted the same
 combination when we counted the partial permutations. Why 6? Because that's
 the value of 3!, of course. There are 3!~different ways to arrange Bubba,
 Phil, and Tiger, since that's just a straight permutation of three
-elements. And so we find that every threesome we want to account for, we
+elements. And so we find that every trio we want to account for, we
 have counted 6 times.
 
 The way to get the correct answer, then, is obviously to correct for this
 overcounting by dividing by 6:
 \[
 \dfrac{45^{\underline{3}}}{3!} = \dfrac{45 \times 44 \times 43}{6} =
-\text{14,190 different threesomes}.
+\text{14,190 different trios}.
 \]
 And in general, that's all we have to do. To find the number of
 combinations of $k$ things taken from a total of $n$ things we have:


### PR DESCRIPTION
'Trio' is already used elsewhere in the chapter.