### PR TITLE
Correct the placement of the vertical bar in a table with three inputs.

### DIFF
--- a/logic.tex
+++ b/logic.tex
@@ -546,7 +546,7 @@ One last identity is this one:
 \index{distributive}
 \begin{nobreak}
 \begin{center}
-\begin{tabular}{c c|c c c c c c c}
+\begin{tabular}{c c c|c c c c c c}
 X & Y & Z & Y$\vee$Z & X$\wedge$(Y$\vee$Z) & X$\wedge$Y & X$\wedge$Z & 
 (X$\wedge$Y)$\vee$(X$\wedge$Z) &
 $A$\footnote{Here, ``$A$'' is


### PR DESCRIPTION
Changes
![before](https://user-images.githubusercontent.com/26764547/203943596-1b79a8b7-0d93-44d5-8667-908c60690bec.png)
to
![after](https://user-images.githubusercontent.com/26764547/203943624-2c822329-5729-47ca-975b-1ba634a4ff77.png)
