### PR TITLE
Add Containerfile and friends.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.toc
 *.ilg
 *.ind
+.container*

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,5 @@
+FROM docker.io/debian
+RUN apt update && apt -y upgrade
+RUN apt install -y make texlive-latex-recommended
+RUN apt install -y texlive-latex-extra
+CMD bash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+brisk.pdf: *.tex
+	pdflatex $(subst .pdf,.tex,$@)
+	makeindex $(subst .pdf,.idx,$@)
+	pdflatex $(subst .pdf,.tex,$@)
+
+pdf: brisk.pdf
+
+env: container_env
+
+### Containers
+CONTAINER_RUNTIME_ENGINE=$(shell which docker || echo "podman")
+CRE=${CONTAINER_RUNTIME_ENGINE}
+IMAGE_TAG=cool-brisk-walk-image
+
+container_env: container_image
+	${CRE} run --rm --interactive --tty --volume `pwd`:/sources --workdir="/sources" ${IMAGE_TAG}
+
+container_image: .container_image_id
+.container_image_id: Containerfile
+	${CRE} build --file $< --tag ${IMAGE_TAG}
+	${CRE} inspect --format {{.Id}} ${IMAGE_TAG} > .container_image_id

--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ $ pdflatex brisk.tex
 $ makeindex brisk.idx 
 $ pdflatex brisk.tex
 ```
+Or the shorter: `make pdf`
+
+If you don't have `pdflatex` in your environment, and don't want to pollute it, you can use
+[containers](https://en.wikipedia.org/wiki/OS-level_virtualization) so long as you have a container
+runtime engine like [`docker`](https://www.docker.com/) or [`podman`](https://podman.io/) on your machine.
+Run `make env` to set up an environment, and `make pdf` inside the container's shell to generate the pdf.
+Consult the [Makefile](Makefile) for further details (and [Makefile Tutorial](https://makefiletutorial.com/)
+to understand Makefiles in general).


### PR DESCRIPTION
Contributors can now run `make env` to spin up an environment to quickly build the book (using `make pdf`). This will be specially useful for drive-by contributors who don't usually use LaTeX on a regular basis and thus don't want to have it in their environment.

Here's how it works:
[![asciicast](https://asciinema.org/a/FAc61f6PhEYBqvT1p03wWd0cX.svg)](https://asciinema.org/a/FAc61f6PhEYBqvT1p03wWd0cX)

The first invocation of `make env` will set everything up (pull container images from container registry, build another container image based on the pulled image, install LaTeX onto that container image, etc.) and will take quite a while (depending on the network bandwidth). But all subsequent `make env` invocations will be as fast as the asciicast shows.

## Issue:
The pdf generated does not have the cover on it. The container image must be missing some latex package or something. It needs to be debugged. But, for drive-by contributors, this might not be too much of an issue as they will probably be concerned only with their changes and how the change renders.