### PR TITLE
Improve readability of summation notation.

### DIFF
--- a/proof.tex
+++ b/proof.tex
@@ -382,11 +382,11 @@ Suppose I want to prove that in the state of Virginia, all legal drinkers
 can vote. Then I could say ``let \textsc{Vote}($n$) be the proposition that
 a citizen of age $n$ can vote."
 
-If I want to prove an algebraic identity, like $\sum_{i=1}^x{i} =
+If I want to prove an algebraic identity, like $\sum\limits_{i=1}^x{i} =
 \frac{x(x+1)}{2}$, then I have to figure out which variable is the one that
 needs to vary across the natural numbers. In this case it's the $x$
 variable in my equation. So I'll say ``let P($n$) be the proposition that
-$\sum_{i=1}^n{i} = \frac{n(n+1)}{2}$." (The choice of the letter ``$n$"
+$\sum\limits_{i=1}^n{i} = \frac{n(n+1)}{2}$." (The choice of the letter ``$n$"
 isn't important here --- it just needs to be a letter that stands for a
 number. We could have chosen anything, even sticking with $x$. Later, we'll
 use ``$k$" as a stand-in, so keep your eyes peeled for that.)
@@ -526,11 +526,11 @@ the numbers from 1 to $x$, where $x$ is any integer at all, you'll get
 $\frac{x}{2}$ sums of $x+1$ each, so the answer will be $\frac{x(x+1)}{2}$.
 
 Now, use mathematical induction to prove that Gauss was right
-(\textit{i.e.}, that $\sum_{i=1}^x{i} = \frac{x(x+1)}{2}$) for all numbers
+(\textit{i.e.}, that $\sum\limits_{i=1}^x{i} = \frac{x(x+1)}{2}$) for all numbers
 $x$.
 
 First we have to cast our problem as a predicate about natural numbers.
-This is easy: we say ``let P($n$) be the proposition that $\sum_{i=1}^n{i}
+This is easy: we say ``let P($n$) be the proposition that $\sum\limits_{i=1}^n{i}
 = \frac{n(n+1)}{2}$."
 
 Then, we satisfy the requirements of induction:


### PR DESCRIPTION
This PR changes this:
![before](https://user-images.githubusercontent.com/26764547/230766959-8b5faa5b-f148-4429-b646-1c1be603c950.png)
to this:
![after](https://user-images.githubusercontent.com/26764547/230766970-40ecbf91-0051-4935-8f02-5675e5b9e21f.png)